### PR TITLE
Add optional CH2-only audio mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 PYTHON := python
 MD5 := md5sum -c --quiet
 
+RGBASMFLAGS += $(if $(CH2_ONLY),-DCH2_ONLY,)
+
 2bpp     := $(PYTHON) extras/pokemontools/gfx.py 2bpp
 1bpp     := $(PYTHON) extras/pokemontools/gfx.py 1bpp
 pic      := $(PYTHON) extras/pokemontools/pic.py compress
@@ -34,11 +36,11 @@ clean:
 
 %_red.o: dep = $(shell $(includes) $(@D)/$*.asm)
 $(pokered_obj): %_red.o: %.asm $$(dep)
-	rgbasm -D _RED -h -o $@ $*.asm
+	rgbasm $(RGBASMFLAGS) -D _RED -h -o $@ $*.asm
 
 %_blue.o: dep = $(shell $(includes) $(@D)/$*.asm)
 $(pokeblue_obj): %_blue.o: %.asm $$(dep)
-	rgbasm -D _BLUE -h -o $@ $*.asm
+	rgbasm $(RGBASMFLAGS) -D _BLUE -h -o $@ $*.asm
 
 pokered_opt  = -sv -k 01 -l 0x33 -m 0x03 -p 0 -r 03 -t "POKEMON RED"
 pokeblue_opt = -sv -k 01 -l 0x33 -m 0x03 -p 0 -r 03 -t "POKEMON BLUE"

--- a/engine/ch2_only.asm
+++ b/engine/ch2_only.asm
@@ -1,0 +1,6 @@
+IF DEF(CH2_ONLY)
+ForceCH2Only::
+    ld a,$22
+    ldh [rNR51],a
+    ret
+ENDC

--- a/home.asm
+++ b/home.asm
@@ -125,6 +125,8 @@ INCLUDE "home/serial.asm"
 INCLUDE "home/timer.asm"
 INCLUDE "home/audio.asm"
 
+INCLUDE "engine/ch2_only.asm"
+
 
 UpdateSprites::
 	ld a, [wUpdateSpritesEnabled]

--- a/home/vblank.asm
+++ b/home/vblank.asm
@@ -75,14 +75,18 @@ VBlank::
 	callba TrackPlayTime ; keep track of time played
 
 	ld a, [wVBlankSavedROMBank]
-	ld [H_LOADEDROMBANK], a
-	ld [MBC1RomBank], a
+        ld [H_LOADEDROMBANK], a
+        ld [MBC1RomBank], a
 
-	pop hl
-	pop de
-	pop bc
-	pop af
-	reti
+IF DEF(CH2_ONLY)
+        call ForceCH2Only
+ENDC
+
+        pop hl
+        pop de
+        pop bc
+        pop af
+        reti
 
 
 DelayFrame::


### PR DESCRIPTION
## Summary
- add ForceCH2Only routine to restrict sound to channel 2
- call ForceCH2Only during vblank when CH2_ONLY build flag is set
- pass CH2_ONLY through Makefile to rgbasm

## Testing
- `make CH2_ONLY=1` *(fails: can't open extras/pokemontools/scan_includes.py; rgbasm not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ecdf0a0148326a56378d3e736110b