### PR TITLE
Allow configurable audio channel mask

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 PYTHON := python
 MD5 := md5sum -c --quiet
 
-RGBASMFLAGS += $(if $(CH2_ONLY),-DCH2_ONLY,)
+RGBASMFLAGS += $(if $(CH2_ONLY),-DCH_MASK=0x22,)
+RGBASMFLAGS += $(if $(CH_MASK),-DCH_MASK=$(CH_MASK),)
 
 2bpp     := $(PYTHON) extras/pokemontools/gfx.py 2bpp
 1bpp     := $(PYTHON) extras/pokemontools/gfx.py 1bpp

--- a/README.md
+++ b/README.md
@@ -9,6 +9,24 @@ It builds the following roms:
 
 To set up the repository, see [**INSTALL.md**](INSTALL.md).
 
+## Channel mask
+
+At build time you can force the NR51 channel mixing mask with the `CH_MASK`
+variable. If it is not specified, a default mask of `0x22` (left and right
+channel 2 only) is used. For compatibility, setting `CH2_ONLY=1` has the same
+effect as `CH_MASK=0x22`.
+
+Examples:
+
+```
+make CH_MASK=0x22    # CH2 only
+make CH_MASK=0x11    # CH1 only
+make CH_MASK=0x44    # CH3 only
+make CH_MASK=0x88    # CH4 only
+make CH_MASK=0x02    # CH2 right only
+make CH_MASK=0x20    # CH2 left only
+```
+
 
 ## See also
 

--- a/engine/ch2_only.asm
+++ b/engine/ch2_only.asm
@@ -1,6 +1,0 @@
-IF DEF(CH2_ONLY)
-ForceCH2Only::
-    ld a,$22
-    ldh [rNR51],a
-    ret
-ENDC

--- a/engine/force_channel_mask.asm
+++ b/engine/force_channel_mask.asm
@@ -1,0 +1,13 @@
+IF DEF(CH_MIXING)
+    ; 互換のため空
+ENDC
+
+IF !DEF(CH_MASK)
+    DEF CH_MASK EQU $22  ; 既定: CH2のみ L/R
+ENDC
+
+SECTION "ChannelMaskRoutine", ROM0
+ForceChannelMask::
+    ld  a, CH_MASK
+    ldh [rNR51], a
+    ret

--- a/home.asm
+++ b/home.asm
@@ -125,7 +125,7 @@ INCLUDE "home/serial.asm"
 INCLUDE "home/timer.asm"
 INCLUDE "home/audio.asm"
 
-INCLUDE "engine/ch2_only.asm"
+INCLUDE "engine/force_channel_mask.asm"
 
 
 UpdateSprites::

--- a/home/vblank.asm
+++ b/home/vblank.asm
@@ -78,9 +78,7 @@ VBlank::
         ld [H_LOADEDROMBANK], a
         ld [MBC1RomBank], a
 
-IF DEF(CH2_ONLY)
-        call ForceCH2Only
-ENDC
+        call ForceChannelMask
 
         pop hl
         pop de


### PR DESCRIPTION
## Summary
- Generalize CH2-only audio routine into a new `ForceChannelMask` that loads a configurable mask
- Call `ForceChannelMask` each VBlank and wire `CH_MASK` through `RGBASMFLAGS`
- Document `CH_MASK` usage for selecting sound output channels

## Testing
- `make red CH_MASK=0x22` *(fails: SyntaxError: Lambda expression parameters cannot be parenthesized)*

------
https://chatgpt.com/codex/tasks/task_e_689ed0b4c3388326a0c5ed1b4ec52e59