### PR TITLE
Add soft panning option for channel mask updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ RGBASMFLAGS += $(if $(CH2_ONLY),-DCH_MASK=0x22,)
 RGBASMFLAGS += $(if $(CH_MASK),-DCH_MASK=$(CH_MASK),)
 RGBASMFLAGS += $(if $(STRICT_MUTE),-DSTRICT_MUTE,)
 RGBASMFLAGS += $(if $(RUNTIME_MASK),-DRUNTIME_MASK,)
+RGBASMFLAGS += $(if $(SOFT_PAN),-DSOFT_PAN,)
 
 2bpp     := $(PYTHON) extras/pokemontools/gfx.py 2bpp
 1bpp     := $(PYTHON) extras/pokemontools/gfx.py 1bpp

--- a/engine/force_channel_mask.asm
+++ b/engine/force_channel_mask.asm
@@ -7,9 +7,21 @@ ENDC
 
 SECTION "ChannelMaskRoutine", ROM0
 ForceChannelMask::
+IF DEF(RUNTIME_MASK)
+    ; a = new channel mask
+IF DEF(SOFT_PAN)
+    call SetChannelMaskSmooth
+    ld  [hCH_MASK], a
+ELSE
+    ldh [rNR51], a
+    ld  [hCH_MASK], a
+ENDC
+    ret
+ELSE
     ld  a, [hCH_MASK]
     ldh [rNR51], a
     ret
+ENDC
 
 ; EnforceStrictMute: 非許可chの音量/DACを毎フレーム落とす
 EnforceStrictMute::

--- a/engine/soft_pan.asm
+++ b/engine/soft_pan.asm
@@ -1,0 +1,20 @@
+IF DEF(SOFT_PAN)
+SECTION "SoftPan", ROM0
+
+; SetChannelMaskSmooth: smoothly update NR51 by muting master volume
+; Temporarily zeroes NR50, writes new mask to NR51, then restores volume
+; a = new channel mask
+SetChannelMaskSmooth::
+    push af
+    ldh  a,[rNR50]      ; FF24 Master Vol
+    ld   b,a            ; Save master volume
+    and  %10001000      ; Keep Vin bits, zero left/right volumes
+    ldh  [rNR50],a      ; Temporarily mute
+    pop  af             ; New mask
+    ldh  [rNR51],a      ; FF25 update
+    ldh  a,[rNR50]
+    ld   a,b            ; Restore master volume
+    ldh  [rNR50],a
+    ret
+ENDC
+

--- a/home.asm
+++ b/home.asm
@@ -127,6 +127,7 @@ INCLUDE "home/timer.asm"
 INCLUDE "home/audio.asm"
 
 INCLUDE "engine/force_channel_mask.asm"
+INCLUDE "engine/soft_pan.asm"
 
 
 UpdateSprites::

--- a/home/vblank.asm
+++ b/home/vblank.asm
@@ -123,11 +123,15 @@ IF DEF(RUNTIME_MASK)
 .all
         ld a, $ff
 .set
-        ldh [hCH_MASK], a
+        call ForceChannelMask
 .after
 ENDC
 
+IF DEF(RUNTIME_MASK)
+        ; ForceChannelMask called only on change
+ELSE
         call ForceChannelMask
+ENDC
 IF DEF(STRICT_MUTE)
 IF !DEF(RUNTIME_MASK)
         call EnforceStrictMute


### PR DESCRIPTION
## Summary
- introduce `SetChannelMaskSmooth` to update NR51 after temporarily muting NR50
- update `ForceChannelMask` and VBlank handler to optionally use smooth mask switching when `SOFT_PAN` and `RUNTIME_MASK` are enabled
- add `SOFT_PAN` build flag in Makefile and include new module

## Testing
- `make red` *(fails: rgbasm: No such file or directory)*
- `make red RUNTIME_MASK=1 SOFT_PAN=1` *(fails: rgbasm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689f3057d7f483269fa6e328de2ff1b2