### PR TITLE
Add NR51 mask HUD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ RGBASMFLAGS += $(if $(CH_MASK),-DCH_MASK=$(CH_MASK),)
 RGBASMFLAGS += $(if $(STRICT_MUTE),-DSTRICT_MUTE,)
 RGBASMFLAGS += $(if $(RUNTIME_MASK),-DRUNTIME_MASK,)
 RGBASMFLAGS += $(if $(SOFT_PAN),-DSOFT_PAN,)
+RGBASMFLAGS += $(if $(SHOW_MASK),-DSHOW_MASK,)
 
 2bpp     := $(PYTHON) extras/pokemontools/gfx.py 2bpp
 1bpp     := $(PYTHON) extras/pokemontools/gfx.py 1bpp

--- a/engine/show_mask.asm
+++ b/engine/show_mask.asm
@@ -1,0 +1,34 @@
+IF DEF(SHOW_MASK)
+SECTION "ShowMask", ROM0
+
+HexDigits: db "0123456789ABCDEF"
+
+ShowMaskHUD::
+    ; a = hCH_MASK
+    ldh  a,[hCH_MASK]
+    ld   b,a
+    ; 上位4bit
+    swap a
+    and  $0F
+    ld   hl,HexDigits
+    add  l
+    ld   l,a
+    jr   nc,+
+    inc  h
++   ld   a,[hl]
+    ; BG左上(0,0)へ
+    ld   hl,$9800
+    ld   [hl],a
+    ; 下位4bit
+    ld   a,b
+    and  $0F
+    ld   hl,HexDigits
+    add  l
+    ld   l,a
+    jr   nc,+
+    inc  h
++   ld   a,[hl]
+    ld   hl,$9801
+    ld   [hl],a
+    ret
+ENDC

--- a/home.asm
+++ b/home.asm
@@ -128,6 +128,7 @@ INCLUDE "home/audio.asm"
 
 INCLUDE "engine/force_channel_mask.asm"
 INCLUDE "engine/soft_pan.asm"
+INCLUDE "engine/show_mask.asm"
 
 
 UpdateSprites::

--- a/home/vblank.asm
+++ b/home/vblank.asm
@@ -138,6 +138,10 @@ IF !DEF(RUNTIME_MASK)
 ENDC
 ENDC
 
+IF DEF(SHOW_MASK)
+        call ShowMaskHUD
+ENDC
+
         pop hl
         pop de
         pop bc


### PR DESCRIPTION
## Summary
- Add `SHOW_MASK` build flag and display current NR51 mask as hex at BG(0,0)
- Hook `ShowMaskHUD` into VBlank routine when enabled
- Pass `SHOW_MASK` macro through `RGBASMFLAGS`

## Testing
- `make red SHOW_MASK=1` *(fails: FATAL: No input file specified)*

------
https://chatgpt.com/codex/tasks/task_e_689f335023c883269fdb2cd113fd174b