### PR TITLE
ci: add release workflow for tagged builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: release-roms
+on:
+  push:
+    tags:
+      - "v*"
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    container: ghcr.io/gbdev/rgbds:latest
+    strategy:
+      fail-fast: false
+      matrix:
+        cfg:
+          - { name: "ch2",     CH_MASK: "0x22", STRICT_MUTE: "0", RUNTIME_MASK: "0", SOFT_PAN: "0", SHOW_MASK: "0" }
+          - { name: "ch2_str", CH_MASK: "0x22", STRICT_MUTE: "1", RUNTIME_MASK: "0", SOFT_PAN: "0", SHOW_MASK: "0" }
+          - { name: "all",     CH_MASK: "0xFF", STRICT_MUTE: "0", RUNTIME_MASK: "0", SOFT_PAN: "0", SHOW_MASK: "0" }
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Build
+        run: |
+          make clean
+          make CH_MASK=${{ matrix.cfg.CH_MASK }} STRICT_MUTE=${{ matrix.cfg.STRICT_MUTE }} RUNTIME_MASK=${{ matrix.cfg.RUNTIME_MASK }} SOFT_PAN=${{ matrix.cfg.SOFT_PAN }} SHOW_MASK=${{ matrix.cfg.SHOW_MASK }}
+      - name: MD5
+        run: make md5
+      - name: PDB
+        run: make pdb GB2PDB=tools/gb2pdb.py PDB_TITLE="PokeJP ${{ matrix.cfg.name }}"
+      - name: Pack artifacts
+        run: |
+          mkdir -p dist
+          cp -v *.gb* dist/ || true
+          cp -v build/*.pdb dist/ || true
+          cp -v build/*.md5 dist/ || true
+          cd dist && sha256sum * > SHA256SUMS
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+          files: |
+            dist/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- build and release ROM artifacts when tags starting with `v` are pushed

## Testing
- `make clean` *(fails: rgbasm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689fcd1781848326b57e92b84b615e3c