### PR TITLE
Add zip target and usage docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PYTHON := python
+				PYTHON := python
 		MD5 := md5sum -c --quiet
 
 RGBASMFLAGS += $(if $(CH2_ONLY),-DCH_MASK=0x22,)
@@ -59,12 +59,14 @@ OUTDIR   ?= build
 EMU      ?= sameboy
 GB2PDB   ?= gb2pdb.py   # 任意の .gb→.pdb 変換スクリプト/ツールのパス
 PDB_TITLE?= PokeJP CHmask
+ZIPNAME  ?= pokejp_chmask.zip
 
 $(OUTDIR):
 	mkdir -p $(OUTDIR)
 
 md5: $(ROM) | $(OUTDIR)
 	md5sum $(ROM) | tee $(OUTDIR)/$(ROM).md5
+	cp $(OUTDIR)/$(ROM).md5 $(OUTDIR)/.md5
 
 run: $(ROM)
 	@command -v $(EMU) >/dev/null 2>&1 || { echo "エミュ $(EMU) が見つかりません"; exit 1; }
@@ -75,6 +77,13 @@ pdb: $(ROM) | $(OUTDIR)
 	@command -v python3 >/dev/null 2>&1 || { echo "python3 が必要です"; exit 1; }
 	@test -f $(GB2PDB) || { echo "$(GB2PDB) が見つかりません（環境変数で上書き可）"; exit 1; }
 	python3 $(GB2PDB) --in $(ROM) --out $(OUTDIR)/$(ROM:.gbc=.pdb) --title "$(PDB_TITLE)"
+	cp $(OUTDIR)/$(ROM:.gbc=.pdb) $(OUTDIR)/.pdb
+
+zip: pdb md5 | $(OUTDIR)
+	@which zip >/dev/null || { echo "zip コマンドが必要です"; exit 1; }
+	rm -f $(OUTDIR)/$(ZIPNAME)
+	zip -j $(OUTDIR)/$(ZIPNAME) $(ROM) build/.pdb build/.md5 README.md
+	@echo "=> $(OUTDIR)/$(ZIPNAME)"
 
 RED_OBJS := audio_red.o main_red.o wram_red.o
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,43 @@ make CH_MASK=0x20    # CH2 left only
 ```
 
 
+## Features
+
+- Force the NR51 channel mask at build time
+- Optional strict mute, soft panning, and runtime channel masking
+- Optional on-screen NR51 mask display
+
+## Build
+
+```
+make CH_MASK=0x22 STRICT_MUTE=1 SOFT_PAN=1
+make md5
+make pdb GB2PDB=tools/gb2pdb.py PDB_TITLE="PokeJP CH2"
+```
+
+## Runtime Controls
+
+When built with `RUNTIME_MASK=1`:
+
+- SELECT+LEFT = CH1, RIGHT = CH2, UP = CH3, DOWN = CH4
+- SELECT+START = All Mute, SELECT+A = All On
+- `SHOW_MASK=1` displays the NR51 mask (hex) in the upper-left corner
+
+## Make targets
+
+- `make`
+- `make clean`
+- `make md5`
+- `make pdb`
+- `make run`
+- `make zip`
+
+## CI & Releases
+
+[![Build](https://github.com/OWNER/REPO/actions/workflows/build.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/build.yml)
+
+Tags matching `v*` trigger an automatic GitHub Release.
+
 ## See also
 
 * Disassembly of [**Pokémon Crystal**][pokecrystal]


### PR DESCRIPTION
## Summary
- document features, build steps, runtime controls, make targets, and CI badge in README
- add `zip` make target with `ZIPNAME` and generic `.pdb`/`.md5` outputs

## Testing
- `make zip` *(fails: rgblink: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689fcf57fdd083269bb96ba1171266ae