### PR TITLE
Move audio mask includes to interrupts

### DIFF
--- a/home.asm
+++ b/home.asm
@@ -124,6 +124,7 @@ INCLUDE "home/fade.asm"
 INCLUDE "home/serial.asm"
 INCLUDE "home/timer.asm"
 INCLUDE "home/audio.asm"
+INCLUDE "home/interrupts.asm"
 
 
 UpdateSprites::

--- a/home/interrupts.asm
+++ b/home/interrupts.asm
@@ -1,0 +1,6 @@
+IF DEF(CH_MASK) || DEF(STRICT_MUTE) || DEF(RUNTIME_MASK) || DEF(SOFT_PAN) || DEF(SHOW_MASK)
+    INCLUDE "engine/channel_mask.inc"
+    INCLUDE "engine/soft_pan.asm"
+    INCLUDE "engine/show_mask.asm"
+    INCLUDE "engine/ch2_only.asm"
+ENDC

--- a/main.asm
+++ b/main.asm
@@ -1,7 +1,7 @@
 INCLUDE "constants.asm"
 
-IMPORT SFX_Shooting_Star
-IMPORT Music_PalletTown
+; IMPORT SFX_Shooting_Star
+; IMPORT Music_PalletTown
 
 NPC_SPRITES_1 EQU $4
 NPC_SPRITES_2 EQU $5
@@ -15,13 +15,6 @@ PICS_4 EQU $C
 PICS_5 EQU $D
 
 INCLUDE "home.asm"
-
-IF DEF(CH_MASK) || DEF(STRICT_MUTE) || DEF(RUNTIME_MASK) || DEF(SOFT_PAN) || DEF(SHOW_MASK)
-    INCLUDE "engine/channel_mask.inc"
-    INCLUDE "engine/soft_pan.asm"
-    INCLUDE "engine/show_mask.asm"
-    INCLUDE "engine/ch2_only.asm" ; 既存の ForceChannelMask/EnforceStrictMute 定義ファイル
-ENDC
 
 
 SECTION "bank1",ROMX,BANK[$1]


### PR DESCRIPTION
## Summary
- comment out incorrect IMPORTs at start of `main.asm`
- remove engine mask includes from `main.asm` and load them via new `home/interrupts.asm`
- include `home/interrupts.asm` from `home.asm`

## Testing
- `make clean`
- `make pokered.gbc CH_MASK=0x22 STRICT_MUTE=1 SOFT_PAN=1` *(fails: syntax error in audio engine, missing `baserom.gbc`)*

------
https://chatgpt.com/codex/tasks/task_e_689ff0e306d0832691ca35a7fcaa7c3f