### PR TITLE
Fix compat macro syntax for older RGBDS

### DIFF
--- a/compat/compat_macros.asm
+++ b/compat/compat_macros.asm
@@ -1,4 +1,4 @@
 ; --- RGBDS 0.4.x 互換のための空マクロ ---
-MACRO IMPORT
+IMPORT: MACRO
 ; no-op（引数は捨てる）
 ENDM


### PR DESCRIPTION
## Summary
- use legacy `IMPORT: MACRO` definition in compat macros for older RGBDS support

## Testing
- `make` *(fails: `Macro "AUDIO_1" not defined`)*

------
https://chatgpt.com/codex/tasks/task_e_68a034b58e988326ba6641210c0e9ba7