### PR TITLE
Fix stack pointer load syntax in vcopy.asm

### DIFF
--- a/home/vcopy.asm
+++ b/home/vcopy.asm
@@ -123,7 +123,7 @@ AutoBgMapTransfer::
 	ld a,[H_AUTOBGTRANSFERENABLED]
 	and a
 	ret z
-	ld hl,[sp + 0]
+	ld hl, sp+0
 	ld a,h
 	ld [H_SPTEMP],a
 	ld a,l
@@ -205,7 +205,7 @@ VBlankCopyBgMap::
 	ld a,[H_VBCOPYBGSRC] ; doubles as enabling byte
 	and a
 	ret z
-	ld hl,[sp + 0]
+	ld hl, sp+0
 	ld a,h
 	ld [H_SPTEMP],a
 	ld a,l
@@ -238,7 +238,7 @@ VBlankCopyDouble::
 	and a
 	ret z
 
-	ld hl, [sp + 0]
+	ld hl, sp+0
 	ld a, h
 	ld [H_SPTEMP], a
 	ld a, l
@@ -290,7 +290,7 @@ VBlankCopyDouble::
 	ld a, h
 	ld [H_VBCOPYDOUBLEDEST + 1], a
 
-	ld hl, [sp + 0]
+	ld hl, sp+0
 	ld a, l
 	ld [H_VBCOPYDOUBLESRC], a
 	ld a, h
@@ -316,7 +316,7 @@ VBlankCopy::
 	and a
 	ret z
 
-	ld hl, [sp + 0]
+	ld hl, sp+0
 	ld a, h
 	ld [H_SPTEMP], a
 	ld a, l
@@ -360,7 +360,7 @@ VBlankCopy::
 	ld a, h
 	ld [H_VBCOPYDEST + 1], a
 
-	ld hl, [sp + 0]
+	ld hl, sp+0
 	ld a, l
 	ld [H_VBCOPYSRC], a
 	ld a, h


### PR DESCRIPTION
## Summary
- fix stack pointer loads in vcopy routines

## Testing
- `make pokered.gbc CH_MASK=0x22 STRICT_MUTE=1 SOFT_PAN=1` *(fails: Macro "AUDIO_1" not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a039ed26508326a2d6ffb9fc4c14a2