### PR TITLE
Fix graphics conversion pattern rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,10 +48,11 @@ pokeblue_opt = -sv -k 01 -l 0x33 -m 0x03 -p 0 -r 03 -t "POKEMON BLUE"
 	rgblink -n $*.sym -o $@ $^
 		rgbfix $($*_opt) $@
 
-%.png:  ;
-	%.2bpp: %.png  ; @$(2bpp) $<
-%.1bpp: %.png  ; @$(1bpp) $<
-%.pic:  %.2bpp ; @$(pic)  $<
+%.png: ;
+
+%.2bpp: %.png ; @$(2bpp) $<
+%.1bpp: %.png ; @$(1bpp) $<
+%.pic: %.2bpp ; @$(pic) $<
 
 # 出力名とツールの既定
 ROM      ?= pokejp.gbc


### PR DESCRIPTION
## Summary
- correct Makefile pattern rules so gfx conversions run

## Testing
- `make pokered.gbc CH_MASK=0x22 STRICT_MUTE=1 SOFT_PAN=1` *(fails: Undefined macro `AUDIO_1` and related rgbasm macro errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a03ba936108326b425c370bea62de5