### PR TITLE
Use HTTPS for extras submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "extras"]
 	path = extras
-	url = git://github.com/kanzure/pokemon-reverse-engineering-tools.git
+	url = https://github.com/kanzure/pokemon-reverse-engineering-tools.git


### PR DESCRIPTION
## Summary
- switch extras submodule to HTTPS to allow cloning in restricted networks

## Testing
- `git submodule update --init --recursive`
- `make pokered.gbc CH_MASK=0x22 STRICT_MUTE=1 SOFT_PAN=1` *(fails: rgbasm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a043e3a0fc8326bf7c1cfd0a7a4c25